### PR TITLE
Rename CSS selector tab_content to tab-content

### DIFF
--- a/app/assets/stylesheets/tab_builder.css.scss
+++ b/app/assets/stylesheets/tab_builder.css.scss
@@ -105,7 +105,7 @@ $current_tab_color: #006EB6;
   }
 }
 
-.tab_content
+.tab-content
 {
   padding-top: 15px;
 }


### PR DESCRIPTION
In order to comply with CodeClimate CSS selector naming standard.

```
Selector tab_content should be written in lowercase with hyphens
```
